### PR TITLE
登録された挑戦目標の表明用のコマンドを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Challenge Every Monthコミュニティ用SlackApp。
 + [x] cem_new: プロジェクトとチャレンジの登録
 + [ ] cem_edit: 登録されたプロジェクトとチャンレンジの修正、変更
 + [ ] cem_delete: 登録されたプロジェクトとチャンレンジの削除
-+ [ ] cem_publish: 登録されたプロジェクトの表明
++ [x] cem_publish: 登録されたプロジェクトの表明
 + [ ] cem_review: 表明されているプロジェクトの振り返り
 
 ### リマインダー設定

--- a/src/commands/cem_publish.ts
+++ b/src/commands/cem_publish.ts
@@ -1,0 +1,99 @@
+import { app } from '../initializers/bolt'
+import { firestore, FieldValue } from '../initializers/firebase'
+import { Block, Message } from '../types/slack'
+
+export default function() {
+  app.command(`/cem_publish`, async ({ payload, ack, context }) => {
+    ack()
+
+    const now = new Date()
+    const thisYear = now.getFullYear()
+    const thisMonth = now.getMonth() + 1
+
+    const challengerRef = firestore
+      .collection(`challengers`)
+      .doc(payload.user_id)
+    const projectsRef = firestore.collection(`projects`)
+    const projectsQuery = projectsRef
+      .where(`challenger`, `==`, challengerRef)
+      .where(`year`, `==`, thisYear)
+      .where(`month`, `==`, thisMonth)
+      .where(`status`, `==`, `draft`)
+
+    try {
+      const projects = await projectsQuery.get().catch(err => {
+        throw new Error(err)
+      })
+      const batch = firestore.batch()
+      const timestamp = FieldValue.serverTimestamp()
+      if (projects.empty) {
+        const msg: Message = {
+          token: context.botToken,
+          text: `プロジェクトが登録されていません`,
+          channel: payload.channel_id,
+          user: payload.user_id,
+        }
+        return app.client.chat.postEphemeral(msg)
+      }
+      const challenger = await challengerRef.get()
+      const challengerName = challenger.data()!.displayName
+      const blocks: Block[] = [
+        {
+          type: `section`,
+          text: {
+            type: `mrkdwn`,
+            text: `${challengerName}さんが${thisYear}年${thisMonth}月の挑戦を表明しました`,
+          },
+        },
+      ]
+      for (const project of projects.docs) {
+        batch.update(project.ref, {
+          status: `published`,
+          updatedAt: timestamp,
+        })
+        let projectText = ``
+        const projData = project.data()
+        projectText += `>>>*${projData.title}*\n`
+        const challenges = await project.ref.collection(`challenges`).get()
+        for (const challenge of challenges.docs) {
+          batch.update(challenge.ref, {
+            status: `trying`,
+            updatedAt: timestamp,
+          })
+          const chalData = challenge.data()
+          projectText += `• ${chalData.name}\n`
+        }
+        projectText += `${projData.description}`
+        blocks.push({
+          type: `section`,
+          text: {
+            type: `mrkdwn`,
+            text: projectText,
+          },
+        })
+      }
+      await batch.commit()
+      const msg: Message = {
+        token: context.botToken,
+        text: {
+          type: `mrkdwn`,
+          text: `${challengerName}さんが${thisYear}年${thisMonth}月の挑戦を表明しました`,
+        },
+        blocks: blocks,
+        channel: payload.channel_id,
+      }
+      return app.client.chat.postMessage(msg).catch(err => {
+        throw new Error(err)
+      })
+    } catch (error) {
+      console.log(`Error:`, error)
+      const msg: Message = {
+        token: context.botToken,
+        text: `Error: ${error}`,
+        channel: payload.channel_id,
+        user: payload.user_id,
+      }
+      return app.client.chat.postEphemeral(msg)
+    }
+  })
+}

--- a/src/commands/cem_register.ts
+++ b/src/commands/cem_register.ts
@@ -1,6 +1,6 @@
 import { app } from '../initializers/bolt'
 import { firestore, FieldValue } from '../initializers/firebase'
-import { Message } from '../types/slack'
+import { Message, Challenger } from '../types/slack'
 
 export default function() {
   app.command(`/cem_register`, async ({ payload, ack, context }) => {
@@ -30,14 +30,15 @@ export default function() {
       }
 
       // firestoreにユーザー作成
+      const challenger: Challenger = {
+        slackName: body.user_name,
+        displayName: body.text || body.user_name,
+        updatedAt: FieldValue.serverTimestamp(),
+        createdAt: FieldValue.serverTimestamp(),
+      }
       await challengersRef
         .doc(body.user_id)
-        .set({
-          slackName: body.user_name,
-          displayName: body.text || body.user_name,
-          updatedAt: FieldValue.serverTimestamp(),
-          createdAt: FieldValue.serverTimestamp(),
-        })
+        .set(challenger)
         .catch(err => {
           throw new Error(err)
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { app } from './initializers/bolt'
 import echo from './commands/echo'
 import cem_register from './commands/cem_register'
 import cem_new from './commands/cem_new'
+import cem_publish from './commands/cem_publish'
 import res_cem_new from './listeners/res_cem_new'
 ;(async () => {
   // Start your app
@@ -13,3 +14,4 @@ echo()
 cem_register()
 cem_new()
 res_cem_new()
+cem_publish()

--- a/src/listeners/res_cem_new.ts
+++ b/src/listeners/res_cem_new.ts
@@ -1,6 +1,6 @@
 import { app } from '../initializers/bolt'
 import { firestore, FieldValue } from '../initializers/firebase'
-import { Message } from '../types/slack'
+import { Message, Project, Challenge } from '../types/slack'
 
 export default function() {
   app.view(`cem_new`, async ({ ack, body, view, context }) => {
@@ -9,46 +9,49 @@ export default function() {
     const payload = view.state.values
     const user = body.user.id
     const metadata = body.view.private_metadata
-    const projectName = payload.projectTitle.projectTitle.value
+    const projectTitle = payload.projectTitle.projectTitle.value
     const year = payload.year.year.selected_option.value
     const month = payload.month.month.selected_option.value
 
     const challengerRef = firestore.collection(`challengers`).doc(user)
     const projectsRef = firestore.collection(`projects`)
+    const timestamp = await FieldValue.serverTimestamp()
     // firestoreにプロジェクト作成
-    const projectRef = await projectsRef
-      .add({
-        challenger: challengerRef,
-        year: Number(year),
-        month: Number(month),
-        title: projectName,
-        description: payload.description.description.value,
-        updatedAt: FieldValue.serverTimestamp(),
-      })
-      .catch(err => {
-        throw new Error(err)
-      })
-    // firestoreに挑戦を行ごとにパーズして保存
-    for (const challenge of payload.challenges.challenges.value.split(/\n/)) {
-      await projectRef
-        .collection(`challenges`)
-        .add({
-          challeger: challengerRef,
-          year: Number(payload.year.year.selected_option.value),
-          month: Number(month),
-          name: challenge,
-          status: `pending`,
-          updatedAt: FieldValue.serverTimestamp(),
-          createdAt: FieldValue.serverTimestamp(),
-        })
-        .catch(err => {
-          throw new Error(err)
-        })
+
+    const project: Project = {
+      challenger: challengerRef,
+      year: Number(year),
+      month: Number(month),
+      title: projectTitle,
+      status: `draft`,
+      description: payload.description.description.value,
+      updatedAt: timestamp,
+      createdAt: timestamp,
     }
+    const projectRef = await projectsRef.add(project).catch(err => {
+      throw new Error(err)
+    })
+    // firestoreに挑戦を行ごとにパーズして保存
+    const batch = firestore.batch()
+    for (const challengeName of payload.challenges.challenges.value.split(
+      /\n/
+    )) {
+      const challenge: Challenge = {
+        challenger: challengerRef,
+        year: Number(payload.year.year.selected_option.value),
+        month: Number(month),
+        name: challengeName,
+        status: `draft`,
+        updatedAt: timestamp,
+        createdAt: timestamp,
+      }
+      batch.set(projectRef.collection(`challenges`).doc(), challenge)
+    }
+    await batch.commit()
     // 成功をSlack通知
     const msg: Message = {
       token: context.botToken,
-      text: `新規プロジェクト[${projectName}]を[${year}-${month}]に登録しました`,
+      text: `新規プロジェクト[${projectTitle}]を[${year}-${month}]に登録しました`,
       channel: metadata,
       user: user,
     }

--- a/src/types/slack.ts
+++ b/src/types/slack.ts
@@ -1,5 +1,5 @@
 export interface TextSection {
-  type: `plain_text` | `mrkdown`
+  type: `plain_text` | `mrkdwn`
   text: string
   emoji?: boolean
 }
@@ -8,6 +8,15 @@ export interface Option {
   value: string
 }
 export interface Block {
+  type: `section` | `actions` | `divider` | `context` | `image`
+  text?: TextSection
+  fields?: TextSection[]
+  image_url?: string
+  alt_text?: string
+  accessory?: any
+  elements?: any
+}
+export interface ModalBlock {
   type: string
   label: TextSection
   block_id: string
@@ -32,17 +41,42 @@ export interface Modal {
     title: TextSection
     submit: TextSection
     close: TextSection
-    blocks: Block[]
+    blocks: ModalBlock[]
   }
 }
 export interface Message {
   token?: string
   channel: string
   mrkdwn?: boolean
-  text?: string
+  text?: string | TextSection
   user?: string
   as_user?: boolean
   blocks?: Block[]
   icon_emoji?: string
   icon_url?: string
+}
+export interface Challenger {
+  slackName: string
+  displayName: string
+  updatedAt: any
+  createdAt: any
+}
+export interface Project {
+  challenger: FirebaseFirestore.DocumentReference
+  year: number
+  month: number
+  title: string
+  status: `draft` | `published` | `reviewed`
+  description: string
+  updatedAt: any
+  createdAt: any
+}
+export interface Challenge {
+  challenger: FirebaseFirestore.DocumentReference
+  year: number
+  month: number
+  name: string
+  status: `draft` | `trying` | `completed` | `incompleted`
+  updatedAt: any
+  createdAt: any
 }


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
RESOLVE: #10
登録された挑戦目標を表明する`/cem_publish`の実装

## 変更内容
+ `/cem_publish`の実装
+ 型定義の追加
+ 既存実装に型の追加
+ 既存実装のFirestoreへの書き込みをbatchを使うように変更

## リリース手順
+ [ ] masterにマージする

## 実行したテスト
+ [x] 開発環境経由での動作確認